### PR TITLE
[PEPC-Boost][1] add types for block assembler rpc + minor refactor

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -22,10 +22,12 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
+	boostTypes "github.com/flashbots/go-boost-utils/types"
 )
 
 //go:generate go run github.com/fjl/gencodec -type PayloadAttributes -field-override payloadAttributesMarshaling -out gen_blockparams.go
@@ -330,4 +332,45 @@ func ExecutionPayloadV2ToBlock(payload *capella.ExecutionPayload) (*types.Block,
 	}
 	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */).WithWithdrawals(withdrawals)
 	return block, nil
+}
+
+func ExecutableDataToCapellaExecutionPayload(data *ExecutableData) (*capella.ExecutionPayload, error) {
+	transactionData := make([]bellatrix.Transaction, len(data.Transactions))
+	for i, tx := range data.Transactions {
+		transactionData[i] = bellatrix.Transaction(tx)
+	}
+
+	withdrawalData := make([]*capella.Withdrawal, len(data.Withdrawals))
+	for i, wd := range data.Withdrawals {
+		withdrawalData[i] = &capella.Withdrawal{
+			Index:          capella.WithdrawalIndex(wd.Index),
+			ValidatorIndex: phase0.ValidatorIndex(wd.Validator),
+			Address:        bellatrix.ExecutionAddress(wd.Address),
+			Amount:         phase0.Gwei(wd.Amount),
+		}
+	}
+
+	baseFeePerGas := new(boostTypes.U256Str)
+	err := baseFeePerGas.FromBig(data.BaseFeePerGas)
+	if err != nil {
+		return nil, err
+	}
+
+	return &capella.ExecutionPayload{
+		ParentHash:    [32]byte(data.ParentHash),
+		FeeRecipient:  [20]byte(data.FeeRecipient),
+		StateRoot:     [32]byte(data.StateRoot),
+		ReceiptsRoot:  [32]byte(data.ReceiptsRoot),
+		LogsBloom:     types.BytesToBloom(data.LogsBloom),
+		PrevRandao:    [32]byte(data.Random),
+		BlockNumber:   data.Number,
+		GasLimit:      data.GasLimit,
+		GasUsed:       data.GasUsed,
+		Timestamp:     data.Timestamp,
+		ExtraData:     data.ExtraData,
+		BaseFeePerGas: *baseFeePerGas,
+		BlockHash:     [32]byte(data.BlockHash),
+		Transactions:  transactionData,
+		Withdrawals:   withdrawalData,
+	}, nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -143,7 +143,7 @@ func encodeTransactions(txs []*types.Transaction) [][]byte {
 	return enc
 }
 
-func decodeTransactions(enc [][]byte) ([]*types.Transaction, error) {
+func DecodeTransactions(enc [][]byte) ([]*types.Transaction, error) {
 	var txs = make([]*types.Transaction, len(enc))
 	for i, encTx := range enc {
 		var tx types.Transaction
@@ -166,7 +166,7 @@ func decodeTransactions(enc [][]byte) ([]*types.Transaction, error) {
 // Withdrawals value will propagate through the returned block. Empty
 // Withdrawals value must be passed via non-nil, length 0 value in params.
 func ExecutableDataToBlock(params ExecutableData) (*types.Block, error) {
-	txs, err := decodeTransactions(params.Transactions)
+	txs, err := DecodeTransactions(params.Transactions)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func ExecutionPayloadToBlock(payload *bellatrix.ExecutionPayload) (*types.Block,
 	for i, txHexBytes := range payload.Transactions {
 		transactionBytes[i] = txHexBytes[:]
 	}
-	txs, err := decodeTransactions(transactionBytes)
+	txs, err := DecodeTransactions(transactionBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func ExecutionPayloadV2ToBlock(payload *capella.ExecutionPayload) (*types.Block,
 	for i, txHexBytes := range payload.Transactions {
 		transactionBytes[i] = txHexBytes[:]
 	}
-	txs, err := decodeTransactions(transactionBytes)
+	txs, err := DecodeTransactions(transactionBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -413,6 +413,10 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 // Transactions implements DerivableList for transactions.
 type Transactions []*Transaction
 
+func (s Transactions) Index(i int) *Transaction {
+	return s[i]
+}
+
 // Len returns the length of s.
 func (s Transactions) Len() int { return len(s) }
 

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -31,6 +31,13 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+// AssemblerTxLists contains the lists of the ToB and RoB txs which are to be
+// used to build a final payload
+type AssemblerTxLists struct {
+	TobTxs *types.Transactions
+	RobTxs *types.Transactions
+}
+
 // BuildPayloadArgs contains the provided parameters for building payload.
 // Check engine-api specification for more details.
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payloadattributesv1


### PR DESCRIPTION
## 📝 Summary

The block assembler is an important component of PEPC-Boost. The block assembler receives the ToB txs sent by the searchers and the RoB block built by the builders and assembles a final block with the TOB txs on the top and the ROB txs in the remaining blocks. 

This PR defines the request types for the block assembler plus does a minor refactor