### PR TITLE
[PEPC-Boost][2] Block Assembler Implementation

### DIFF
--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -429,6 +429,9 @@ func (api *BlockValidationAPI) BlockAssembler(params *BlockAssemblerRequest) (*c
 	}
 
 	finalPayload, err := engine.ExecutableDataToCapellaExecutionPayload(resolvedBlock.ExecutionPayload)
+	if err != nil {
+		return nil, err
+	}
 
 	return finalPayload, nil
 }

--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -9,6 +9,7 @@ import (
 
 	bellatrixapi "github.com/attestantio/go-builder-client/api/bellatrix"
 	capellaapi "github.com/attestantio/go-builder-client/api/capella"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	bellatrixUtil "github.com/attestantio/go-eth2-client/util/bellatrix"
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -343,4 +345,90 @@ func (b *BlockAssemblerRequest) UnmarshalJSON(data []byte) error {
 	b.RobPayload = *blockRequest
 
 	return nil
+}
+
+func (api *BlockValidationAPI) BlockAssembler(params *BlockAssemblerRequest) (*capella.ExecutionPayload, error) {
+	log.Info("BlockAssembler", "tobTxs", len(params.TobTxs.Transactions), "robPayload", params.RobPayload)
+	transactionBytes := make([][]byte, len(params.TobTxs.Transactions))
+	for i, txHexBytes := range params.TobTxs.Transactions {
+		transactionBytes[i] = txHexBytes[:]
+	}
+	decodedTobTxs, err := engine.DecodeTransactions(transactionBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	robBlock, err := engine.ExecutionPayloadV2ToBlock(params.RobPayload.ExecutionPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	tobTxs := types.Transactions(decodedTobTxs)
+
+	// TODO - check for gas limits
+	// TODO - support for payouts
+
+	// TODO - if there are no TOB txs then we can just simulate the block rather then re-assembling it.
+	// These are TODOs for now to simplify integration testing
+
+	// check if there are any duplicate txs
+	// we can error out if there is a nonce gap
+	// TODO - don't error out, but drop the duplicate tx in the ROB block
+	seenTxMap := make(map[common.Hash]struct{})
+	for _, tx := range tobTxs {
+		// If we see nonce reuse in TOB then fail
+		if _, ok := seenTxMap[tx.Hash()]; ok {
+			return nil, errors.New("duplicate tx")
+		}
+		seenTxMap[tx.Hash()] = struct{}{}
+	}
+	for _, tx := range robBlock.Transactions() {
+		// if we see nonce re-use in TOB vs ROB then drop txs the txs in ROB
+		if _, ok := seenTxMap[tx.Hash()]; ok {
+			return nil, errors.New("duplicate tx")
+		}
+		seenTxMap[tx.Hash()] = struct{}{}
+	}
+
+	withdrawals := make(types.Withdrawals, len(params.RobPayload.ExecutionPayload.Withdrawals))
+	for i, withdrawal := range params.RobPayload.ExecutionPayload.Withdrawals {
+		withdrawals[i] = &types.Withdrawal{
+			Index:     uint64(withdrawal.Index),
+			Validator: uint64(withdrawal.ValidatorIndex),
+			Address:   common.Address(withdrawal.Address),
+			Amount:    uint64(withdrawal.Amount),
+		}
+	}
+
+	// assemble the txs in map[sender]txs format and pass it in the BuildPayload call
+
+	robTxs := robBlock.Transactions()
+	block, err := api.eth.Miner().PayloadAssembler(&miner.BuildPayloadArgs{
+		Parent:    common.Hash(params.RobPayload.ExecutionPayload.ParentHash),
+		Timestamp: params.RobPayload.ExecutionPayload.Timestamp,
+		// TODO - this should be relayer fee recipient. We will implement payouts later
+		FeeRecipient: common.Address(params.RobPayload.Message.ProposerFeeRecipient),
+		GasLimit:     params.RegisteredGasLimit,
+		Random:       params.RobPayload.ExecutionPayload.PrevRandao,
+		Withdrawals:  withdrawals,
+		BlockHook:    nil,
+		AssemblerTxs: miner.AssemblerTxLists{
+			TobTxs: &tobTxs,
+			RobTxs: &robTxs,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	resolvedBlock := block.ResolveFull()
+	if resolvedBlock == nil {
+		return nil, errors.New("unable to resolve block")
+	}
+	if resolvedBlock.ExecutionPayload == nil {
+		return nil, errors.New("nil execution payload")
+	}
+
+	finalPayload, err := engine.ExecutableDataToCapellaExecutionPayload(resolvedBlock.ExecutionPayload)
+
+	return finalPayload, nil
 }

--- a/miner/contract_simulator_test.go
+++ b/miner/contract_simulator_test.go
@@ -201,7 +201,7 @@ func TestSimulatorState(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		block, _, err := w.getSealingBlock(b.chain.CurrentBlock().Hash(), b.chain.CurrentHeader().Time+12, testAddress1, 0, common.Hash{}, nil, false, nil)
+		block, _, err := w.getSealingBlock(b.chain.CurrentBlock().Hash(), b.chain.CurrentHeader().Time+12, testAddress1, 0, common.Hash{}, nil, false, nil, AssemblerTxLists{})
 		require.NoError(t, err)
 		require.NotNil(t, block)
 		if requireTx != -1 {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -308,6 +308,10 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 // Accepts the block, time at which orders were taken, bundles which were used to build the block and all bundles that were considered for the block
 type BlockHookFn = func(*types.Block, *big.Int, time.Time, []types.SimulatedBundle, []types.SimulatedBundle, []types.UsedSBundle)
 
+func (miner *Miner) PayloadAssembler(args *BuildPayloadArgs) (*Payload, error) {
+	return miner.worker.payloadAssembler(args)
+}
+
 // BuildPayload builds the payload according to the provided parameters.
 func (miner *Miner) BuildPayload(args *BuildPayloadArgs) (*Payload, error) {
 	return miner.worker.buildPayload(args)

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -49,6 +49,7 @@ type BuildPayloadArgs struct {
 	Random       common.Hash       // The provided randomness value
 	Withdrawals  types.Withdrawals // The provided withdrawals
 	BlockHook    BlockHookFn
+	AssemblerTxs AssemblerTxLists // The provided lists of ToB and RoB txs by the payload assembler
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.
@@ -228,7 +229,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 	// Build the initial version with no transaction included. It should be fast
 	// enough to run. The empty payload can at least make sure there is something
 	// to deliver for not missing slot.
-	empty, _, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.GasLimit, args.Random, args.Withdrawals, true, args.BlockHook)
+	empty, _, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.GasLimit, args.Random, args.Withdrawals, true, args.BlockHook, AssemblerTxLists{})
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +253,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 			select {
 			case <-timer.C:
 				start := time.Now()
-				block, fees, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.GasLimit, args.Random, args.Withdrawals, false, args.BlockHook)
+				block, fees, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.GasLimit, args.Random, args.Withdrawals, false, args.BlockHook, AssemblerTxLists{})
 				if err == nil {
 					payload.update(block, fees, time.Since(start))
 				}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1668,6 +1668,7 @@ func (w *worker) generateWork(params *generateParams) (*types.Block, *big.Int, e
 		return finalizeFn(work, time.Now(), nil, nil, nil, true)
 	}
 
+	// TODO - we need to yet brainstorm validator payouts in the case of PEPC-Boost
 	var paymentTxReserve *proposerTxReservation
 	// no need of adding payouts if we are assembling txs
 	if !work.isAssembler {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1423,10 +1423,8 @@ func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) 
 	return blockBundles, allBundles, usedSbundles, mempoolTxHashes, err
 }
 
-// fillTransactions retrieves the pending transactions from the txpool and fills them
-// into the given sealing block. The transaction selection and ordering strategy can
-// be customized with the plugin in the future.
-// Returns error if any, otherwise the bundles that made it into the block and all bundles that passed simulation
+// fillAssemblerTransactions builds a block by merging the ToB txs and RoB txs by putting the ToB txs at the top and filling the rest with the
+// block with the RoB txs
 func (w *worker) fillAssemblerTransactions(interrupt *int32, env *environment) ([]types.SimulatedBundle, []types.SimulatedBundle, map[common.Hash]struct{}, error) {
 
 	assemblerTxs := env.assemblerTxs

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1871,16 +1871,17 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, gasLimit uint64, random common.Hash, withdrawals types.Withdrawals, noTxs bool, blockHook BlockHookFn, AssemblerTxs AssemblerTxLists) (*types.Block, *big.Int, error) {
 	req := &getWorkReq{
 		params: &generateParams{
-			timestamp:   timestamp,
-			forceTime:   true,
-			parentHash:  parent,
-			coinbase:    coinbase,
-			gasLimit:    gasLimit,
-			random:      random,
-			withdrawals: withdrawals,
-			noUncle:     true,
-			noTxs:       noTxs,
-			onBlock:     blockHook,
+			timestamp:    timestamp,
+			forceTime:    true,
+			parentHash:   parent,
+			coinbase:     coinbase,
+			gasLimit:     gasLimit,
+			random:       random,
+			withdrawals:  withdrawals,
+			noUncle:      true,
+			noTxs:        noTxs,
+			onBlock:      blockHook,
+			assemblerTxs: AssemblerTxs,
 		},
 		result: make(chan *newPayloadResult, 1),
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -103,10 +103,12 @@ type environment struct {
 	coinbase  common.Address
 	profit    *big.Int
 
-	header   *types.Header
-	txs      []*types.Transaction
-	receipts []*types.Receipt
-	uncles   map[common.Hash]*types.Header
+	header       *types.Header
+	txs          []*types.Transaction
+	receipts     []*types.Receipt
+	uncles       map[common.Hash]*types.Header
+	isAssembler  bool
+	assemblerTxs AssemblerTxLists
 }
 
 // copy creates a deep copy of environment.
@@ -883,7 +885,7 @@ func (w *worker) resultLoop() {
 }
 
 // makeEnv creates a new environment for the sealing block.
-func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase common.Address) (*environment, error) {
+func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase common.Address, assemblerTxs AssemblerTxLists) (*environment, error) {
 	// Retrieve the parent state to execute on top and start a prefetcher for
 	// the miner to speed block sealing up a bit.
 	state, err := w.chain.StateAt(parent.Root)
@@ -894,15 +896,20 @@ func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase co
 
 	// Note the passed coinbase may be different with header.Coinbase.
 	env := &environment{
-		signer:    types.MakeSigner(w.chainConfig, header.Number),
-		state:     state,
-		coinbase:  coinbase,
-		ancestors: mapset.NewSet[common.Hash](),
-		family:    mapset.NewSet[common.Hash](),
-		header:    header,
-		uncles:    make(map[common.Hash]*types.Header),
-		profit:    new(big.Int),
+		signer:       types.MakeSigner(w.chainConfig, header.Number),
+		state:        state,
+		coinbase:     coinbase,
+		ancestors:    mapset.NewSet[common.Hash](),
+		family:       mapset.NewSet[common.Hash](),
+		header:       header,
+		uncles:       make(map[common.Hash]*types.Header),
+		profit:       new(big.Int),
+		assemblerTxs: assemblerTxs,
 	}
+	if (assemblerTxs.TobTxs != nil && assemblerTxs.TobTxs.Len() > 0) || (assemblerTxs.RobTxs != nil && assemblerTxs.RobTxs.Len() > 0) {
+		env.isAssembler = true
+	}
+
 	// when 08 is processed ancestors contain 07 (quick block)
 	for _, ancestor := range w.chain.GetBlocksFromHash(parent.Hash(), 7) {
 		for _, uncle := range ancestor.Uncles() {
@@ -1095,6 +1102,95 @@ func (w *worker) commitBundle(env *environment, txs types.Transactions, interrup
 	return nil
 }
 
+func (w *worker) commitTransactionWrapper(env *environment, interrupt *int32, tx *types.Transaction, coalescedLogs []*types.Log) error {
+	// Check interruption signal and abort building if it's fired.
+	if interrupt != nil {
+		if signal := atomic.LoadInt32(interrupt); signal != commitInterruptNone {
+			return signalToErr(signal)
+		}
+	}
+	// If we don't have enough gas for any further transactions then we're done.
+	if env.gasPool.Gas() < params.TxGas {
+		log.Trace("Not enough gas for further transactions", "have", env.gasPool, "want", params.TxGas)
+		return nil
+	}
+
+	// Error may be ignored here. The error has already been checked
+	// during transaction acceptance is the transaction pool.
+	from, _ := types.Sender(env.signer, tx)
+	logs, err := w.commitTransaction(env, tx)
+	switch {
+	case errors.Is(err, core.ErrGasLimitReached):
+		// Pop the current out-of-gas transaction without shifting in the next from the account
+		log.Trace("Gas limit exceeded for current block", "sender", from)
+
+	case errors.Is(err, core.ErrNonceTooLow):
+		// New head notification data race between the transaction pool and miner, shift
+		log.Trace("Skipping transaction with low nonce", "sender", from, "nonce", tx.Nonce())
+
+	case errors.Is(err, core.ErrNonceTooHigh):
+		// Reorg notification data race between the transaction pool and miner, skip account =
+		log.Trace("Skipping account with hight nonce", "sender", from, "nonce", tx.Nonce())
+
+	case errors.Is(err, nil):
+		// Everything ok, collect the logs and shift in the next transaction from the same account
+		coalescedLogs = append(coalescedLogs, logs...)
+		env.tcount++
+
+	case errors.Is(err, types.ErrTxTypeNotSupported):
+		// Pop the unsupported transaction without shifting in the next from the account
+		log.Trace("Skipping unsupported transaction type", "sender", from, "type", tx.Type())
+
+	default:
+		// Strange error, discard the transaction and get the next in line (note, the
+		// nonce-too-high clause will prevent us from executing in vain).
+		log.Debug("Transaction failed, account skipped", "hash", tx.Hash(), "err", err)
+	}
+
+	return nil
+}
+
+func (w *worker) commitAssemblyTransactions(env *environment, assemblerTxs AssemblerTxLists, interrupt *int32) error {
+	gasLimit := env.header.GasLimit
+	if env.gasPool == nil {
+		env.gasPool = new(core.GasPool).AddGas(gasLimit)
+	}
+	var coalescedLogs []*types.Log
+
+	// first go thru TOB txs
+	for _, tx := range *assemblerTxs.TobTxs {
+		err := w.commitTransactionWrapper(env, interrupt, tx, coalescedLogs)
+		if err != nil {
+			return err
+		}
+	}
+
+	// now go thru ROB txs
+	for _, tx := range *assemblerTxs.RobTxs {
+		err := w.commitTransactionWrapper(env, interrupt, tx, coalescedLogs)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !w.isRunning() && len(coalescedLogs) > 0 {
+		// We don't push the pendingLogsEvent while we are sealing. The reason is that
+		// when we are sealing, the worker will regenerate a sealing block every 3 seconds.
+		// In order to avoid pushing the repeated pendingLog, we disable the pending log pushing.
+
+		// make a copy, the state caches the logs and these logs get "upgraded" from pending to mined
+		// logs by filling in the block hash when the block was mined by the local miner. This can
+		// cause a race condition if a log was "upgraded" before the PendingLogsEvent is processed.
+		cpy := make([]*types.Log, len(coalescedLogs))
+		for i, l := range coalescedLogs {
+			cpy[i] = new(types.Log)
+			*cpy[i] = *l
+		}
+		w.pendingLogsFeed.Send(cpy)
+	}
+	return nil
+}
+
 func (w *worker) commitTransactions(env *environment, txs *types.TransactionsByPriceAndNonce, interrupt *int32) error {
 	gasLimit := env.header.GasLimit
 	if env.gasPool == nil {
@@ -1191,16 +1287,17 @@ func (w *worker) commitTransactions(env *environment, txs *types.TransactionsByP
 
 // generateParams wraps various of settings for generating sealing task.
 type generateParams struct {
-	timestamp   uint64            // The timstamp for sealing task
-	forceTime   bool              // Flag whether the given timestamp is immutable or not
-	parentHash  common.Hash       // Parent block hash, empty means the latest chain head
-	coinbase    common.Address    // The fee recipient address for including transaction
-	gasLimit    uint64            // The validator's requested gas limit target
-	random      common.Hash       // The randomness generated by beacon chain, empty before the merge
-	withdrawals types.Withdrawals // List of withdrawals to include in block.
-	noUncle     bool              // Flag whether the uncle block inclusion is allowed
-	noTxs       bool              // Flag whether an empty block without any transaction is expected
-	onBlock     BlockHookFn       // Callback to call for each produced block
+	timestamp    uint64            // The timstamp for sealing task
+	forceTime    bool              // Flag whether the given timestamp is immutable or not
+	parentHash   common.Hash       // Parent block hash, empty means the latest chain head
+	coinbase     common.Address    // The fee recipient address for including transaction
+	gasLimit     uint64            // The validator's requested gas limit target
+	random       common.Hash       // The randomness generated by beacon chain, empty before the merge
+	withdrawals  types.Withdrawals // List of withdrawals to include in block.
+	noUncle      bool              // Flag whether the uncle block inclusion is allowed
+	noTxs        bool              // Flag whether an empty block without any transaction is expected
+	onBlock      BlockHookFn       // Callback to call for each produced block
+	assemblerTxs AssemblerTxLists  // The transactions that the assembler wants to make a block out of
 }
 
 func doPrepareHeader(genParams *generateParams, chain *core.BlockChain, config *Config, chainConfig *params.ChainConfig, extra []byte, engine consensus.Engine) (*types.Header, *types.Header, error) {
@@ -1277,7 +1374,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	// Could potentially happen if starting to mine in an odd state.
 	// Note genParams.coinbase can be different with header.Coinbase
 	// since clique algorithm can modify the coinbase field in header.
-	env, err := w.makeEnv(parent, header, genParams.coinbase)
+	env, err := w.makeEnv(parent, header, genParams.coinbase, genParams.assemblerTxs)
 	if err != nil {
 		log.Error("Failed to create sealing context", "err", err)
 		return nil, err
@@ -1311,6 +1408,10 @@ func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) 
 		mempoolTxHashes map[common.Hash]struct{}
 		err             error
 	)
+	if env.isAssembler {
+		blockBundles, allBundles, mempoolTxHashes, err = w.fillAssemblerTransactions(interrupt, env)
+		return blockBundles, allBundles, usedSbundles, mempoolTxHashes, err
+	}
 	switch w.flashbots.algoType {
 	case ALGO_GREEDY, ALGO_GREEDY_BUCKETS:
 		blockBundles, allBundles, usedSbundles, mempoolTxHashes, err = w.fillTransactionsAlgoWorker(interrupt, env)
@@ -1320,6 +1421,32 @@ func (w *worker) fillTransactionsSelectAlgo(interrupt *int32, env *environment) 
 		blockBundles, allBundles, mempoolTxHashes, err = w.fillTransactions(interrupt, env)
 	}
 	return blockBundles, allBundles, usedSbundles, mempoolTxHashes, err
+}
+
+// fillTransactions retrieves the pending transactions from the txpool and fills them
+// into the given sealing block. The transaction selection and ordering strategy can
+// be customized with the plugin in the future.
+// Returns error if any, otherwise the bundles that made it into the block and all bundles that passed simulation
+func (w *worker) fillAssemblerTransactions(interrupt *int32, env *environment) ([]types.SimulatedBundle, []types.SimulatedBundle, map[common.Hash]struct{}, error) {
+
+	assemblerTxs := env.assemblerTxs
+	totalTxsToAssemble := assemblerTxs.RobTxs.Len() + assemblerTxs.TobTxs.Len()
+
+	mempoolHashes := make(map[common.Hash]struct{}, totalTxsToAssemble)
+	for _, tx := range *assemblerTxs.TobTxs {
+		mempoolHashes[tx.Hash()] = struct{}{}
+	}
+	for _, tx := range *assemblerTxs.RobTxs {
+		mempoolHashes[tx.Hash()] = struct{}{}
+	}
+
+	if totalTxsToAssemble > 0 {
+		if err := w.commitAssemblyTransactions(env, env.assemblerTxs, interrupt); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	return []types.SimulatedBundle{}, []types.SimulatedBundle{}, mempoolHashes, nil
 }
 
 // fillTransactions retrieves the pending transactions from the txpool and fills them
@@ -1528,8 +1655,10 @@ func (w *worker) generateWork(params *generateParams) (*types.Block, *big.Int, e
 			gasUsedGauge.Update(int64(block.GasUsed()))
 			transactionNumGauge.Update(int64(len(env.txs)))
 		}
-		if params.onBlock != nil {
-			go params.onBlock(block, profit, orderCloseTime, blockBundles, allBundles, usedSbundles)
+		if !env.isAssembler {
+			if params.onBlock != nil {
+				go params.onBlock(block, profit, orderCloseTime, blockBundles, allBundles, usedSbundles)
+			}
 		}
 
 		return block, profit, nil
@@ -1539,11 +1668,14 @@ func (w *worker) generateWork(params *generateParams) (*types.Block, *big.Int, e
 		return finalizeFn(work, time.Now(), nil, nil, nil, true)
 	}
 
-	paymentTxReserve, err := w.proposerTxPrepare(work, &validatorCoinbase)
-	if err != nil {
-		return nil, nil, err
+	var paymentTxReserve *proposerTxReservation
+	// no need of adding payouts if we are assembling txs
+	if !work.isAssembler {
+		paymentTxReserve, err = w.proposerTxPrepare(work, &validatorCoinbase)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
-
 	orderCloseTime := time.Now()
 
 	blockBundles, allBundles, usedSbundles, mempoolTxHashes, err := w.fillTransactionsSelectAlgo(nil, work)
@@ -1574,9 +1706,11 @@ func (w *worker) generateWork(params *generateParams) (*types.Block, *big.Int, e
 		return finalizeFn(work, orderCloseTime, blockBundles, allBundles, usedSbundles, true)
 	}
 
-	err = w.proposerTxCommit(work, &validatorCoinbase, paymentTxReserve)
-	if err != nil {
-		return nil, nil, err
+	if !work.isAssembler {
+		err = w.proposerTxCommit(work, &validatorCoinbase, paymentTxReserve)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	return finalizeFn(work, orderCloseTime, blockBundles, allBundles, usedSbundles, false)
@@ -1596,9 +1730,12 @@ func (w *worker) finalizeBlock(work *environment, withdrawals types.Withdrawals,
 		return block, big.NewInt(0), nil
 	}
 
-	blockProfit, err := w.checkProposerPayment(work, validatorCoinbase)
-	if err != nil {
-		return nil, nil, err
+	var blockProfit *big.Int
+	if !work.isAssembler {
+		blockProfit, err = w.checkProposerPayment(work, validatorCoinbase)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	return block, blockProfit, nil
@@ -1731,7 +1868,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 // getSealingBlock generates the sealing block based on the given parameters.
 // The generation result will be passed back via the given channel no matter
 // the generation itself succeeds or not.
-func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, gasLimit uint64, random common.Hash, withdrawals types.Withdrawals, noTxs bool, blockHook BlockHookFn) (*types.Block, *big.Int, error) {
+func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, gasLimit uint64, random common.Hash, withdrawals types.Withdrawals, noTxs bool, blockHook BlockHookFn, AssemblerTxs AssemblerTxLists) (*types.Block, *big.Int, error) {
 	req := &getWorkReq{
 		params: &generateParams{
 			timestamp:   timestamp,

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -658,7 +658,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 
 	// This API should work even when the automatic sealing is not enabled
 	for _, c := range cases {
-		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, 0, c.random, nil, true, nil)
+		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, 0, c.random, nil, true, nil, AssemblerTxLists{})
 		if c.expectErr {
 			if err == nil {
 				t.Error("Expect error but get nil")
@@ -674,7 +674,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 	// This API should work even when the automatic sealing is enabled
 	w.start()
 	for _, c := range cases {
-		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, 0, c.random, nil, false, nil)
+		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, 0, c.random, nil, false, nil, AssemblerTxLists{})
 		if c.expectErr {
 			if err == nil {
 				t.Error("Expect error but get nil")
@@ -822,7 +822,7 @@ func testBundles(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		block, _, err := w.getSealingBlock(w.chain.CurrentBlock().Hash(), w.chain.CurrentHeader().Time+12, testUserAddress, 0, common.Hash{}, nil, false, nil)
+		block, _, err := w.getSealingBlock(w.chain.CurrentBlock().Hash(), w.chain.CurrentHeader().Time+12, testUserAddress, 0, common.Hash{}, nil, false, nil, AssemblerTxLists{})
 		require.NoError(t, err)
 
 		state, err := w.chain.State()


### PR DESCRIPTION
## 📝 Summary

This PR contains an implementation of the Block Assembler RPC.

The Block Assembler RPC is called by the PEPC-Boost relay. When the builder submits a block to the PEPC-Boost relayer, the relayer checks the existing ToB tx cache for the particular slot and parent hash. If it finds the ToB txs, the sum of the ToB tx value and RoB tx value is the highest seen so far. We then call the Block Assembler RPC API, sending the ToB txs, and the Builder submit request as parameters. The block assembler assembles the block with the ToB txs at the top and the RoB txs in the rest of the block. If successful, it returns the final execution payload to the relayer which it stores as the final block.