### PR TITLE
[PEPC-Boost][4] Add TOB validation RPC

### DIFF
--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -375,7 +375,6 @@ func (api *BlockValidationAPI) ValidateTobSubmission(params *TobValidationReques
 
 	// check if payout tx is present at the end
 	payoutTx := decodedTobTxs[len(decodedTobTxs)-1]
-	fmt.Printf("payout tx data: %s\n", payoutTx.Data())
 	if payoutTx.To() != nil && payoutTx.To().String() != params.ProposerFeeRecipient {
 		return fmt.Errorf("payout tx recipient %s does not match proposer fee recipient %s", payoutTx.To().String(), params.ProposerFeeRecipient)
 	}

--- a/eth/block-validation/api.go
+++ b/eth/block-validation/api.go
@@ -375,10 +375,11 @@ func (api *BlockValidationAPI) ValidateTobSubmission(params *TobValidationReques
 
 	// check if payout tx is present at the end
 	payoutTx := decodedTobTxs[len(decodedTobTxs)-1]
+	fmt.Printf("payout tx data: %s\n", payoutTx.Data())
 	if payoutTx.To() != nil && payoutTx.To().String() != params.ProposerFeeRecipient {
 		return fmt.Errorf("payout tx recipient %s does not match proposer fee recipient %s", payoutTx.To().String(), params.ProposerFeeRecipient)
 	}
-	if payoutTx.Data() != nil {
+	if len(payoutTx.Data()) != 0 {
 		return fmt.Errorf("payout tx data is malformed")
 	}
 	if payoutTx.Value().Cmp(big.NewInt(0)) == 0 {
@@ -387,7 +388,7 @@ func (api *BlockValidationAPI) ValidateTobSubmission(params *TobValidationReques
 
 	for i, tx := range decodedTobTxs {
 		if tx.To() == nil {
-			return fmt.Errorf("tx: %s is a contract creation tx. ontract creation txs are not allowed", tx.Hash())
+			return fmt.Errorf("tx: %s is a contract creation tx. contract creation txs are not allowed", tx.Hash())
 		}
 		statedb.SetTxContext(tx.Hash(), i)
 		tmpGasUsed := uint64(0)


### PR DESCRIPTION
## 📝 Summary

Add an RPC endpoint that takes in the TOB txs, parent hash, and the proposer fee recipient and validates whether TOB txs are valid. It ensures the following as of now:
1. Whether the proposer payout is valid.
2. Whether the TOB txs are not smart contract creations
3. Simulates the TOB txs on the top of the parent hash.