### PR TITLE
[PEPC-Boost] Use rob_blocks api

### DIFF
--- a/builder/relay.go
+++ b/builder/relay.go
@@ -158,7 +158,7 @@ func (r *RemoteRelay) SubmitBlock(msg *bellatrix.SubmitBlockRequest, _ Validator
 func (r *RemoteRelay) SubmitBlockCapella(msg *capella.SubmitBlockRequest, _ ValidatorData) error {
 	log.Info("submitting block to remote relay", "endpoint", r.config.Endpoint)
 
-	endpoint := r.config.Endpoint + "/relay/v1/builder/blocks"
+	endpoint := r.config.Endpoint + "/relay/v1/builder/rob_blocks"
 	if r.cancellationsEnabled {
 		endpoint = endpoint + "?cancellations=true"
 	}


### PR DESCRIPTION
## 📝 Summary

We have separated out the api to submit rob_blocks and full_blocks in the relayer