### PR TITLE
[PEPC-Boost] Consider ToB gas limit reservations

### DIFF
--- a/builder/local_relay.go
+++ b/builder/local_relay.go
@@ -240,6 +240,10 @@ func (r *LocalRelay) GetValidatorForSlot(nextSlot uint64) (ValidatorData, error)
 	return ValidatorData{}, errors.New("missing validator")
 }
 
+func (r *LocalRelay) GetTobGasReservations() (uint64, error) {
+	return 0, nil
+}
+
 func (r *LocalRelay) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	slot, err := strconv.Atoi(vars["slot"])

--- a/builder/relay.go
+++ b/builder/relay.go
@@ -224,6 +224,21 @@ func (r *RemoteRelay) getSlotValidatorMapFromRelay() (map[uint64]ValidatorData, 
 	return res, nil
 }
 
+func (r *RemoteRelay) GetTobGasReservations() (uint64, error) {
+	var tobReservations uint64
+
+	code, err := SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, r.config.Endpoint+"/relay/v1/builder/validators", nil, &tobReservations)
+	if err != nil {
+		return 0, err
+	}
+
+	if code > 299 {
+		return 0, fmt.Errorf("non-ok response code %d from relay", code)
+	}
+
+	return tobReservations, nil
+}
+
 func (r *RemoteRelay) Config() RelayConfig {
 	return r.config
 }

--- a/builder/relay.go
+++ b/builder/relay.go
@@ -227,7 +227,7 @@ func (r *RemoteRelay) getSlotValidatorMapFromRelay() (map[uint64]ValidatorData, 
 func (r *RemoteRelay) GetTobGasReservations() (uint64, error) {
 	var tobReservations uint64
 
-	code, err := SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, r.config.Endpoint+"/relay/v1/builder/validators", nil, &tobReservations)
+	code, err := SendHTTPRequest(context.TODO(), *http.DefaultClient, http.MethodGet, r.config.Endpoint+"/relay/v1/builder/tob_gas_reservations", nil, &tobReservations)
 	if err != nil {
 		return 0, err
 	}

--- a/builder/relay_aggregator.go
+++ b/builder/relay_aggregator.go
@@ -111,6 +111,10 @@ func (r *RemoteRelayAggregator) GetValidatorForSlot(nextSlot uint64) (ValidatorD
 	return ValidatorData{}, ErrValidatorNotFound
 }
 
+func (r *RemoteRelayAggregator) GetTobGasReservations() (uint64, error) {
+	return 0, nil
+}
+
 func (r *RemoteRelayAggregator) updateRelayRegistrations(nextSlot uint64, registrationsCh chan *RelayValidatorRegistration, topRegistrationCh chan ValidatorData) {
 	defer close(topRegistrationCh)
 


### PR DESCRIPTION
## 📝 Summary

We now limit the amount of gas units transactions can have on the ToB. The amount is computed in the relayer. the builder has to read the value from the relayer.